### PR TITLE
don't force support for EOL versions of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
+sudo: false
+
 php:
-    - 5.4
     - 5.5
     - 5.6
+    - 7.0
     - hhvm
-matrix:
-    allow_failures:
-        - php: hhvm
 
 before_script:
     - composer install -n


### PR DESCRIPTION
use travis containers & start supporting php 7.0