### PR TITLE
Check that lock file exists, before trying to delete it.

### DIFF
--- a/spec/TH/Lock/FileLockSpec.php
+++ b/spec/TH/Lock/FileLockSpec.php
@@ -124,4 +124,13 @@ class FileLockSpec extends ObjectBehavior
 
         $this->release();
     }
+
+    public function it_does_not_throw_when_lock_file_does_not_exists()
+    {
+        $this->acquire();
+
+        unlink($this->lock_file);
+
+        $this->release();
+    }
 }

--- a/src/FileLock.php
+++ b/src/FileLock.php
@@ -97,7 +97,9 @@ class FileLock implements Lock
         }
 
         if ($this->remove_on_release && $this->flock(LOCK_EX | LOCK_NB)) {
-            unlink($this->lock_file);
+            if (is_file($this->lock_file)) {
+                unlink($this->lock_file);
+            }
         }
 
         $this->flock(LOCK_UN);


### PR DESCRIPTION
This need to be done, because when using FileLock::BLOCKING locking method, if there two separate process acquiring the same lock, when one finishes it deletes lock file, when next one finishes it throws "No such file or directory" exception, since lock file no longer exists.