### PR TITLE
Fix README usage of shared lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $lock->acquire();
 
 // read /path/to/file
 
-$lock->acquire();
+$lock->release();
 
 // other processes can now acquire an exclusive lock on the file if no other shared lock remains.
 ```


### PR DESCRIPTION
The README said that to release a shared lock, we should use the $lock->acquire() function again. I changed it to $lock->release().